### PR TITLE
Find and use pre-installed Intel MKL versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ links = "mkl_intel_lp64"
 exclude = ["mkl_lib/mkl.tar.xz"]
 
 [build-dependencies]
+pkg-config = "0.3"
 rust-crypto = "0.2"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 extern crate crypto;
+extern crate pkg_config;
 
 use crypto::md5;
 use crypto::digest::Digest;
@@ -75,13 +76,18 @@ fn expand(archive: &Path, out_dir: &Path) {
 }
 
 fn main() {
+    if pkg_config::find_library("mkl-dynamic-lp64-iomp").is_ok() {
+        println!("Returning early, pre-installed Intel MKL was found.");
+        return;
+    }
+
     let out_dir = PathBuf::from(var("OUT_DIR").unwrap());
     let archive_path = out_dir.join(mkl::ARCHIVE);
 
     if archive_path.exists() && calc_md5(&archive_path) == mkl::MD5SUM {
         println!("Use existings archive");
     } else {
-        println!("Downlaod archive");
+        println!("Download archive");
         download(mkl::URI, mkl::ARCHIVE, &out_dir);
         let sum = calc_md5(&archive_path);
         if sum != mkl::MD5SUM {


### PR DESCRIPTION
Intel MKL provides pkg-config files since Intel MKL 2018 Update 1.
Update the build script to exit early iff a preinstalled MKL could be
found with pkg-config.