### PR TITLE
Rewrite pkg-config handler in intel-mkl-tool

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,14 +43,12 @@ jobs:
         command: test
         args: --manifest-path=${{ matrix.target }}/Cargo.toml
 
-  linux-with-mkl:
+  docker:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
     - name: Test with mkl-rust container
-      run: |
-        cd intel-mkl-tool
-        ./docker-test.sh
+      run: intel-mkl-tool/docker-test.sh
 
   check-format:
     runs-on: ubuntu-18.04

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,15 @@ jobs:
         command: test
         args: --manifest-path=${{ matrix.target }}/Cargo.toml
 
+  linux-with-mkl:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Test with mkl-rust container
+      run: |
+        cd intel-mkl-tool
+        ./docker-test.sh
+
   check-format:
     runs-on: ubuntu-18.04
     steps:

--- a/intel-mkl-tool/Cargo.toml
+++ b/intel-mkl-tool/Cargo.toml
@@ -16,6 +16,7 @@ cli = ["structopt", "env_logger"]
 [dependencies]
 anyhow = "1.0.31"
 curl = "0.4.25"
+derive_more = "0.99.7"
 dirs = "2.0.2"
 glob = "0.3.0"
 log = "0.4.8"

--- a/intel-mkl-tool/docker-test.sh
+++ b/intel-mkl-tool/docker-test.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 set -exu
 
-docker run -it --rm                   \
+script_dir="$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)"
+
+docker run --rm                       \
   -u $(id -u):$(id -g)                \
-  -v $PWD:/src                        \
+  -v $script_dir:/src                 \
   rustmath/mkl-rust:1.43.0-2020.1.217 \
   cargo test with_mkl -- --ignored

--- a/intel-mkl-tool/docker-test.sh
+++ b/intel-mkl-tool/docker-test.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 set -exu
-docker run -it -u $(id -u):$(id -g) --rm -v $PWD:/src rustmath/mkl-rust:1.43.0-2020.1.217 cargo run -- seek
+
+docker run -it --rm                   \
+  -u $(id -u):$(id -g)                \
+  -v $PWD:/src                        \
+  rustmath/mkl-rust:1.43.0-2020.1.217 \
+  cargo test with_mkl -- --ignored

--- a/intel-mkl-tool/docker-test.sh
+++ b/intel-mkl-tool/docker-test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -exu
+docker run -it -u $(id -u):$(id -g) --rm -v $PWD:/src rustmath/mkl-rust:1.43.0-2020.1.217 cargo run -- seek

--- a/intel-mkl-tool/docker-test.sh
+++ b/intel-mkl-tool/docker-test.sh
@@ -2,9 +2,8 @@
 set -exu
 
 script_dir="$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)"
+image="rustmath/mkl-rust:1.43.0-2020.1.217"
+option="--rm -u $(id -u):$(id -g) -v $script_dir:/src"
 
-docker run --rm                       \
-  -u $(id -u):$(id -g)                \
-  -v $script_dir:/src                 \
-  rustmath/mkl-rust:1.43.0-2020.1.217 \
-  cargo test with_mkl -- --ignored
+docker run $option $image cargo test with_mkl -- --ignored
+docker run $option $image cargo run -- seek

--- a/intel-mkl-tool/src/cli.rs
+++ b/intel-mkl-tool/src/cli.rs
@@ -1,4 +1,5 @@
 use anyhow::*;
+use intel_mkl_tool::*;
 use std::{env, path::PathBuf};
 use structopt::StructOpt;
 
@@ -33,25 +34,20 @@ fn main() -> Result<()> {
             let path = if let Some(path) = path {
                 path
             } else {
-                intel_mkl_tool::xdg_home_path()
+                xdg_home_path()
             };
-            intel_mkl_tool::download_default(&path)?;
+            download_default(&path)?;
         }
 
         Opt::Seek {} => {
-            if let Some(path) = intel_mkl_tool::seek_pkg_config() {
-                println!("{}", path.display());
-                return Ok(());
+            for lib in LinkConfig::available() {
+                // len("mkl-dynamic-ilp64-iomp") == 22
+                println!("{:<22} at {}", lib.name(), lib.path().display());
             }
-            if let Some(path) = intel_mkl_tool::seek_home() {
-                println!("{}", path.display());
-                return Ok(());
-            }
-            bail!("Intel-MKL not found.");
         }
 
         Opt::Package { path } => {
-            let _out = intel_mkl_tool::package(&path)?;
+            let _out = package(&path)?;
         }
     }
     Ok(())

--- a/intel-mkl-tool/src/cli.rs
+++ b/intel-mkl-tool/src/cli.rs
@@ -41,8 +41,10 @@ fn main() -> Result<()> {
 
         Opt::Seek {} => {
             for lib in LinkConfig::available() {
-                // len("mkl-dynamic-ilp64-iomp") == 22
-                println!("{:<22} at {}", lib.name(), lib.path().display());
+                println!("{}", lib.name());
+                for (name, path) in lib.targets().iter() {
+                    println!("  {:<25} at {}", name, path.as_ref().unwrap().display());
+                }
             }
         }
 

--- a/intel-mkl-tool/src/config.rs
+++ b/intel-mkl-tool/src/config.rs
@@ -1,6 +1,5 @@
 use anyhow::*;
 use derive_more::Display;
-use std::path::*;
 
 pub const VALID_CONFIGS: &[&str] = &[
     "mkl-dynamic-ilp64-iomp",
@@ -84,11 +83,6 @@ impl Config {
     /// identifier used in pkg-config
     pub fn name(&self) -> String {
         format!("mkl-{}-{}-{}", self.link, self.index_size, self.parallel)
-    }
-
-    /// Download MKL archive and cache into $XDG_DATA_HOME
-    pub fn download(&self) -> PathBuf {
-        todo!()
     }
 }
 

--- a/intel-mkl-tool/src/config.rs
+++ b/intel-mkl-tool/src/config.rs
@@ -1,0 +1,55 @@
+use derive_more::Display;
+
+#[derive(Debug, Clone, Copy, PartialEq, Display)]
+pub enum Link {
+    #[display(fmt = "static")]
+    Static,
+    #[display(fmt = "dynamic")]
+    Shared,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Display)]
+pub enum IndexSize {
+    #[display(fmt = "lp64")]
+    LP64,
+    #[display(fmt = "ilp64")]
+    ILP64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Display)]
+pub enum Parallel {
+    #[display(fmt = "iomp")]
+    OpenMP,
+    #[display(fmt = "seq")]
+    Sequential,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Config {
+    link: Link,
+    index_size: IndexSize,
+    parallel: Parallel,
+}
+
+impl Config {
+    fn as_pkg_config_name(&self) -> String {
+        format!("mkl-{}-{}-{}", self.link, self.index_size, self.parallel)
+    }
+
+    /// Check if pkg-config has a corresponding setting
+    pub fn is_pkg_config_managed(&self) -> bool {
+        pkg_config::Config::new()
+            .cargo_metadata(false)
+            .probe(&self.as_pkg_config_name())
+            .is_ok()
+    }
+
+    /// Check if archive is cached in $XDG_DATA_HOME
+    pub fn is_cached(&self) -> bool {
+        todo!()
+    }
+
+    pub fn print_cargo_metadata(&self) {
+        //
+    }
+}

--- a/intel-mkl-tool/src/config.rs
+++ b/intel-mkl-tool/src/config.rs
@@ -1,4 +1,6 @@
+use anyhow::*;
 use derive_more::Display;
+use std::path::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Display)]
 pub enum Link {
@@ -32,24 +34,82 @@ pub struct Config {
 }
 
 impl Config {
-    fn as_pkg_config_name(&self) -> String {
+    pub fn from_name(_name: &str) -> Result<Self> {
+        todo!()
+    }
+
+    /// identifier used in pkg-config
+    pub fn name(&self) -> String {
         format!("mkl-{}-{}-{}", self.link, self.index_size, self.parallel)
     }
 
+    fn base_dir(&self) -> PathBuf {
+        todo!()
+    }
+
+    /// Static and shared library lists to be linked
+    pub fn libs(
+        &self,
+    ) -> (
+        Vec<PathBuf>, /* static */
+        Vec<String>,  /* shared */
+    ) {
+        // FIXME this implementation is for Linux, fix for Windows and macOS
+        let mut static_libs = Vec::new();
+        let mut shared_libs = vec!["pthread".into(), "m".into(), "dl".into()];
+
+        let mut add = |name: &str| match self.link {
+            Link::Static => {
+                let base_dir: PathBuf = self.base_dir();
+                let path = base_dir.join(format!("lib{}.a", name));
+                assert!(path.exists());
+                static_libs.push(path);
+            }
+            Link::Shared => {
+                shared_libs.push(name.to_string());
+            }
+        };
+
+        add("mkl_core");
+        match self.index_size {
+            IndexSize::LP64 => {
+                add("mkl_intel_lp64");
+            }
+            IndexSize::ILP64 => {
+                add("mkl_intel_ilp64");
+            }
+        };
+        match self.parallel {
+            Parallel::OpenMP => {
+                add("iomp5");
+                add("mkl_intel_thread");
+            }
+            Parallel::Sequential => {
+                add("mkl_sequential");
+            }
+        };
+        (static_libs, shared_libs)
+    }
+
     /// Check if pkg-config has a corresponding setting
-    pub fn is_pkg_config_managed(&self) -> bool {
+    pub fn pkg_config(&self) -> Option<pkg_config::Library> {
         pkg_config::Config::new()
             .cargo_metadata(false)
-            .probe(&self.as_pkg_config_name())
-            .is_ok()
+            .probe(&self.name())
+            .ok()
     }
 
     /// Check if archive is cached in $XDG_DATA_HOME
-    pub fn is_cached(&self) -> bool {
+    pub fn exists(&self) -> bool {
+        todo!()
+    }
+
+    /// Download MKL archive and cache into $XDG_DATA_HOME
+    pub fn download(&self) -> PathBuf {
         todo!()
     }
 
     pub fn print_cargo_metadata(&self) {
-        //
+        todo!()
     }
 }

--- a/intel-mkl-tool/src/config.rs
+++ b/intel-mkl-tool/src/config.rs
@@ -84,6 +84,30 @@ impl Config {
     pub fn name(&self) -> String {
         format!("mkl-{}-{}-{}", self.link, self.index_size, self.parallel)
     }
+
+    /// Common components
+    pub fn libs(&self) -> Vec<String> {
+        let mut libs = Vec::new();
+        libs.push("mkl_core".into());
+        match self.index_size {
+            IndexSize::LP64 => {
+                libs.push("mkl_intel_lp64".into());
+            }
+            IndexSize::ILP64 => {
+                libs.push("mkl_intel_ilp64".into());
+            }
+        };
+        match self.parallel {
+            Parallel::OpenMP => {
+                libs.push("iomp5".into());
+                libs.push("mkl_intel_thread".into());
+            }
+            Parallel::Sequential => {
+                libs.push("mkl_sequential".into());
+            }
+        };
+        libs
+    }
 }
 
 #[cfg(test)]

--- a/intel-mkl-tool/src/download.rs
+++ b/intel-mkl-tool/src/download.rs
@@ -23,7 +23,7 @@ fn download_archive_to_buffer(url: &str) -> Result<Vec<u8>> {
 }
 
 pub fn download(out_dir: &Path, prefix: &str, year: u32, update: u32) -> Result<()> {
-    let mkl_core = out_dir.join(format!("{}mkl_core.{}", mkl::PREFIX, mkl::EXT));
+    let mkl_core = out_dir.join(format!("{}mkl_core.{}", mkl::PREFIX, mkl::EXTENSION_SHARED));
     if mkl_core.exists() {
         info!("Archive already exists: {}", out_dir.display());
         return Ok(());

--- a/intel-mkl-tool/src/lib.rs
+++ b/intel-mkl-tool/src/lib.rs
@@ -3,10 +3,12 @@ use std::path::*;
 
 mod config;
 mod download;
+mod link;
 mod package;
 
 pub use config::*;
 pub use download::*;
+pub use link::*;
 pub use package::*;
 
 const S3_ADDR: &'static str = "https://s3-ap-northeast-1.amazonaws.com/rust-intel-mkl";

--- a/intel-mkl-tool/src/lib.rs
+++ b/intel-mkl-tool/src/lib.rs
@@ -1,9 +1,11 @@
 use log::*;
 use std::path::*;
 
+mod config;
 mod download;
 mod package;
 
+pub use config::*;
 pub use download::*;
 pub use package::*;
 

--- a/intel-mkl-tool/src/lib.rs
+++ b/intel-mkl-tool/src/lib.rs
@@ -14,7 +14,8 @@ const S3_ADDR: &'static str = "https://s3-ap-northeast-1.amazonaws.com/rust-inte
 #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 mod mkl {
     pub const ARCHIVE: &'static str = "mkl_linux64";
-    pub const EXT: &'static str = "so";
+    pub const EXTENSION_STATIC: &'static str = "a";
+    pub const EXTENSION_SHARED: &'static str = "so";
     pub const PREFIX: &'static str = "lib";
     pub const VERSION_YEAR: u32 = 2019;
     pub const VERSION_UPDATE: u32 = 5;
@@ -23,7 +24,8 @@ mod mkl {
 #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
 mod mkl {
     pub const ARCHIVE: &'static str = "mkl_macos64";
-    pub const EXT: &'static str = "dylib";
+    pub const EXTENSION_STATIC: &'static str = "a";
+    pub const EXTENSION_SHARED: &'static str = "dylib";
     pub const PREFIX: &'static str = "lib";
     pub const VERSION_YEAR: u32 = 2019;
     pub const VERSION_UPDATE: u32 = 3;
@@ -32,7 +34,8 @@ mod mkl {
 #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
 mod mkl {
     pub const ARCHIVE: &'static str = "mkl_windows64";
-    pub const EXT: &'static str = "lib";
+    pub const EXTENSION_STATIC: &'static str = "lib";
+    pub const EXTENSION_SHARED: &'static str = "lib";
     pub const PREFIX: &'static str = "";
     pub const VERSION_YEAR: u32 = 2019;
     pub const VERSION_UPDATE: u32 = 5;

--- a/intel-mkl-tool/src/link.rs
+++ b/intel-mkl-tool/src/link.rs
@@ -52,10 +52,9 @@ impl LinkConfig {
                         config,
                         path: path.clone(),
                     });
-                } else {
-                    warn!("{} not found in {}", &core, path.display());
                 }
-            } else if !lib.include_paths.is_empty() {
+            }
+            if !lib.include_paths.is_empty() {
                 // assumes following directory structure:
                 //
                 // - mkl
@@ -68,12 +67,11 @@ impl LinkConfig {
                         path: path.canonicalize()?.clone(),
                     });
                 }
-            } else {
-                warn!(
-                    "No link path exists in pkg-config entry of {}",
-                    config.name()
-                );
             }
+            warn!(
+                "No link path exists in pkg-config entry of {}",
+                config.name()
+            );
         }
 
         // XDG_DATA_HOME

--- a/intel-mkl-tool/src/link.rs
+++ b/intel-mkl-tool/src/link.rs
@@ -1,0 +1,74 @@
+use crate::*;
+use anyhow::*;
+
+/// Handler for found library
+#[derive(Debug, Clone, PartialEq)]
+pub struct LinkConfig {
+    config: Config,
+    path: PathBuf,
+}
+
+impl LinkConfig {
+    pub fn name(&self) -> String {
+        self.config.name()
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    pub fn from_config(config: Config) -> Result<Self> {
+        let path = config.base_dir()?;
+        Ok(Self { config, path })
+    }
+
+    pub fn available() -> Vec<Self> {
+        VALID_CONFIGS
+            .iter()
+            .flat_map(|name| Self::from_config(Config::from_str(name).unwrap()))
+            .collect()
+    }
+
+    pub fn print_cargo_metadata(&self) -> Result<()> {
+        let (_static, _shared) = self.libs()?;
+        todo!()
+    }
+
+    /// Static and shared library lists to be linked
+    fn libs(&self) -> Result<(Vec<PathBuf>, Vec<String>)> {
+        // FIXME this implementation is for Linux, fix for Windows and macOS
+        let mut static_libs = Vec::new();
+        let mut shared_libs = vec!["pthread".into(), "m".into(), "dl".into()];
+
+        let mut add = |name: &str| match self.config.link {
+            Link::Static => {
+                let path = self.path.join(format!("lib{}.a", name));
+                assert!(path.exists());
+                static_libs.push(path);
+            }
+            Link::Shared => {
+                shared_libs.push(name.to_string());
+            }
+        };
+
+        add("mkl_core");
+        match self.config.index_size {
+            IndexSize::LP64 => {
+                add("mkl_intel_lp64");
+            }
+            IndexSize::ILP64 => {
+                add("mkl_intel_ilp64");
+            }
+        };
+        match self.config.parallel {
+            Parallel::OpenMP => {
+                add("iomp5");
+                add("mkl_intel_thread");
+            }
+            Parallel::Sequential => {
+                add("mkl_sequential");
+            }
+        };
+        Ok((static_libs, shared_libs))
+    }
+}

--- a/intel-mkl-tool/src/link.rs
+++ b/intel-mkl-tool/src/link.rs
@@ -99,20 +99,22 @@ impl LinkConfig {
             .collect()
     }
 
-    pub fn print_cargo_metadata(&self) -> Result<()> {
-        let (_static, _shared) = self.libs()?;
+    pub fn print_cargo_metadata(&self) {
+        let (_static, _shared) = self.libs();
         todo!()
     }
 
     /// Static and shared library lists to be linked
-    fn libs(&self) -> Result<(Vec<PathBuf>, Vec<String>)> {
-        // FIXME this implementation is for Linux, fix for Windows and macOS
+    fn libs(&self) -> (Vec<PathBuf>, Vec<String>) {
         let mut static_libs = Vec::new();
         let mut shared_libs = vec!["pthread".into(), "m".into(), "dl".into()];
 
         let mut add = |name: &str| match self.config.link {
             Link::Static => {
-                let path = self.path.join(format!("lib{}.a", name));
+                let path =
+                    self.path
+                        .join(format!("{}{}.{}", mkl::PREFIX, name, mkl::EXTENSION_STATIC));
+                // this existance must be ensured by previous step
                 assert!(path.exists());
                 static_libs.push(path);
             }
@@ -139,7 +141,7 @@ impl LinkConfig {
                 add("mkl_sequential");
             }
         };
-        Ok((static_libs, shared_libs))
+        (static_libs, shared_libs)
     }
 }
 

--- a/intel-mkl-tool/src/link.rs
+++ b/intel-mkl-tool/src/link.rs
@@ -142,3 +142,15 @@ impl LinkConfig {
         Ok((static_libs, shared_libs))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Test all available MKL are detected
+    #[ignore]
+    #[test]
+    fn with_mkl_availables() {
+        assert_eq!(LinkConfig::available().len(), 8);
+    }
+}

--- a/intel-mkl-tool/src/link.rs
+++ b/intel-mkl-tool/src/link.rs
@@ -9,17 +9,89 @@ pub struct LinkConfig {
 }
 
 impl LinkConfig {
+    /// Get the directory where the library exists
+    ///
+    /// This will seek followings in this order:
+    ///
+    /// - `$OUT_DIR`
+    ///   - Only for build.rs
+    ///   - This exists only when the previous build downloads archive here
+    /// - pkg-config `${name}`
+    ///   - Installed by package manager or official downloader
+    /// - `$XDG_DATA_HOME/intel-mkl-tool/${name}`
+    ///   - Downloaded by this crate
+    ///
+    /// Returns error if no library found
+    ///
+    pub fn from_config(config: Config) -> Result<Self> {
+        let core = match config.link {
+            Link::Static => format!("{}mkl_core.{}", mkl::PREFIX, mkl::EXTENSION_STATIC),
+            Link::Shared => format!("{}mkl_core.{}", mkl::PREFIX, mkl::EXTENSION_SHARED),
+        };
+
+        // OUT_DIR
+        if let Ok(dir) = std::env::var("OUT_DIR") {
+            let out_dir = PathBuf::from(dir);
+            if out_dir.join(&core).exists() {
+                return Ok(Self {
+                    config,
+                    path: out_dir,
+                });
+            }
+        }
+
+        // pkg-config
+        if let Ok(lib) = pkg_config::Config::new()
+            .cargo_metadata(false)
+            .probe(&config.name())
+        {
+            if !lib.link_paths.is_empty() {
+                let path = &lib.link_paths[0];
+                if path.join(&core).exists() {
+                    return Ok(Self {
+                        config,
+                        path: path.clone(),
+                    });
+                } else {
+                    warn!("{} not found in {}", &core, path.display());
+                }
+            } else if !lib.include_paths.is_empty() {
+                // assumes following directory structure:
+                //
+                // - mkl
+                //   - include      <- lib.include_paths detects this
+                //   - lib/intel64
+                let path = lib.include_paths[0].join("../lib/intel64");
+                if path.join(&core).exists() {
+                    return Ok(Self {
+                        config,
+                        path: path.canonicalize()?.clone(),
+                    });
+                }
+            } else {
+                warn!(
+                    "No link path exists in pkg-config entry of {}",
+                    config.name()
+                );
+            }
+        }
+
+        // XDG_DATA_HOME
+        let path = xdg_home_path().join(config.name());
+        if path.exists() && path.join(&core).exists() {
+            return Ok(Self { config, path });
+        }
+
+        // None found
+        bail!("No library found for {}", config.name());
+    }
+
     pub fn name(&self) -> String {
         self.config.name()
     }
 
     pub fn path(&self) -> &Path {
         &self.path
-    }
-
-    pub fn from_config(config: Config) -> Result<Self> {
-        let path = config.base_dir()?;
-        Ok(Self { config, path })
     }
 
     pub fn available() -> Vec<Self> {

--- a/intel-mkl-tool/src/package.rs
+++ b/intel-mkl-tool/src/package.rs
@@ -67,7 +67,7 @@ pub fn package(mkl_path: &Path) -> Result<()> {
     create_archive(
         &glob(
             mkl_path
-                .join(format!("lib/intel64/*.{}", mkl::EXT))
+                .join(format!("lib/intel64/*.{}", mkl::EXTENSION_SHARED))
                 .to_str()
                 .unwrap(),
         )?


### PR DESCRIPTION
Split from #31 

intel_mkl_tool::Config
--------------------------------
A struct corresponding to each pkg-config entry, e.g. `mkl-dynamic-lp64-iomp`, as described in [Intel® Math Kernel Library (Intel® MKL) and pkg-config tool](https://software.intel.com/content/www/us/en/develop/articles/intel-math-kernel-library-intel-mkl-and-pkg-config-tool.html)

intel_mkl_tool::LinkConfig
--------------------------------------
Found MKL configure. This seeks static or shared library based on `Config` from

- `$OUT_DIR`
- `pkg-config ${name}`
- `$XDG_DATA_HOME/intel-mkl-tool/${name}`