### PR TITLE
Ready for release 0.6.0+mkl2020.1

### DIFF
--- a/intel-mkl-src/Cargo.toml
+++ b/intel-mkl-src/Cargo.toml
@@ -34,4 +34,4 @@ xdg-data-home = []
 
 [build-dependencies]
 anyhow = "1"
-intel-mkl-tool = { version = "0.2.0-alpha.1", path = "../intel-mkl-tool", default-features = false }
+intel-mkl-tool = { version = "0.2.0", path = "../intel-mkl-tool", default-features = false }

--- a/intel-mkl-src/Cargo.toml
+++ b/intel-mkl-src/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intel-mkl-src"
-version = "0.6.0-alpha.1"
+version = "0.6.0+mkl2020.1"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2018"
 
@@ -14,7 +14,7 @@ build = "build.rs"
 links = "mkl_core"
 
 [features]
-default = ["download", "mkl-dynamic-lp64-iomp"]
+default = ["download", "mkl-static-ilp64-seq"]
 
 # MKL config
 # https://software.intel.com/content/www/us/en/develop/articles/intel-math-kernel-library-intel-mkl-and-pkg-config-tool.html

--- a/intel-mkl-sys/Cargo.toml
+++ b/intel-mkl-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intel-mkl-sys"
-version = "0.2.0-alpha.0"
+version = "0.2.0+mkl2020.1"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2018"
 
@@ -10,7 +10,7 @@ keywords    = ["ffi"]
 license     = "MIT"
 
 [features]
-default = ["download", "mkl-dynamic-lp64-iomp"]
+default = ["download", "mkl-static-ilp64-seq"]
 
 # MKL config
 # https://software.intel.com/content/www/us/en/develop/articles/intel-math-kernel-library-intel-mkl-and-pkg-config-tool.html

--- a/intel-mkl-sys/Cargo.toml
+++ b/intel-mkl-sys/Cargo.toml
@@ -27,7 +27,7 @@ mkl-dynamic-ilp64-seq  = ["intel-mkl-src/mkl-dynamic-ilp64-seq"]
 download = ["intel-mkl-src/download"]
 
 [dependencies]
-intel-mkl-src = { path = "../intel-mkl-src", version = "0.6.0-alpha.0", default-features = false }
+intel-mkl-src = { path = "../intel-mkl-src", version = "0.6.0", default-features = false }
 
 [dev-dependencies]
 criterion = "0.3.0"

--- a/intel-mkl-tool/Cargo.toml
+++ b/intel-mkl-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intel-mkl-tool"
-version = "0.2.0-alpha.1"
+version = "0.2.0+mkl2020.1"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Resolve #22 

- Change default to `mkl-static-ilp64-seq` as in README
- Drop `-alpha.*` from dependencies