### PR TITLE
tweaks to mac & debugging

### DIFF
--- a/intel-mkl-tool/src/download.rs
+++ b/intel-mkl-tool/src/download.rs
@@ -34,7 +34,9 @@ fn read_from_url(url: &str) -> Result<Vec<u8>> {
                 Ok(new_data.len())
             })
             .unwrap();
-        transfer.perform().unwrap();
+
+        let msg = format!("Error while downloading URL: {}", url);
+        transfer.perform().expect(&msg);
     }
     Ok(data)
 }

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -111,6 +111,7 @@ impl Entry {
         // /opt/intel/mkl
         let opt_mkl = PathBuf::from("/opt/intel/mkl");
         if opt_mkl.exists() {
+            targets.seek(opt_mkl.join("lib"));
             targets.seek(opt_mkl.join("lib/intel64"));
         }
 


### PR DESCRIPTION
- give a better error message if we can't find the right mkl package.
- latest MKL on Mac needs a different search path.