### PR TITLE
Bump zstd's version to 0.6.1

### DIFF
--- a/intel-mkl-tool/Cargo.toml
+++ b/intel-mkl-tool/Cargo.toml
@@ -24,7 +24,7 @@ pkg-config = "0.3.17"
 # archive
 curl = { version = "0.4.29", optional = true }
 tar  = { version = "0.4.29", optional = true }
-zstd = { version = "0.5.3",  optional = true }
+zstd = { version = "0.6.1",  optional = true }
 
 # CLI
 structopt = { version = "0.3.15", optional = true }


### PR DESCRIPTION
I need a newer version for the `zstd` dependency in my tree because of `polars`:
```
error: failed to select a version for `zstd-sys`.
    ... required by package `zstd-safe v2.0.5+zstd.1.4.5`
    ... which is depended on by `zstd v0.5.3+zstd.1.4.5`
    ... which is depended on by `intel-mkl-tool v0.2.0+mkl2020.1`
    ... which is depended on by `intel-mkl-src v0.6.0+mkl2020.1`
    ... which is depended on by `linfa v0.3.1 (/home/lorenz/Documents/projects/linfa)`
    ... which is depended on by `linfa-bayes v0.3.1 (/home/lorenz/Documents/projects/linfa/algorithms/linfa-bayes)`
versions that meet the requirements `=1.4.17` are: 1.4.17+zstd.1.4.5

the package `zstd-sys` links to the native library `zstd`, but it conflicts with a previous package which links to `zstd` as well:
package `zstd-sys v1.4.19+zstd.1.4.8`
    ... which is depended on by `zstd-safe v3.0.0+zstd.1.4.8`
    ... which is depended on by `zstd v0.6.0+zstd.1.4.8`
    ... which is depended on by `parquet v3.0.0`
    ... which is depended on by `polars-core v0.12.0`
    ... which is depended on by `polars v0.12.0`
    ... which is depended on by `linfa v0.3.1 (/home/lorenz/Documents/projects/linfa)`
    ... which is depended on by `linfa-bayes v0.3.1 (/home/lorenz/Documents/projects/linfa/algorithms/linfa-bayes)`
```