### PR TITLE
Bump version of zstd to 0.8

### DIFF
--- a/intel-mkl-src/Cargo.toml
+++ b/intel-mkl-src/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 links = "mkl_core"
 
 [features]
-default = ["download", "mkl-static-ilp64-iomp"]
+default = ["download", "mkl-dynamic-ilp64-iomp"]
 
 # MKL config
 # https://software.intel.com/content/www/us/en/develop/articles/intel-math-kernel-library-intel-mkl-and-pkg-config-tool.html

--- a/intel-mkl-src/Cargo.toml
+++ b/intel-mkl-src/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 links = "mkl_core"
 
 [features]
-default = ["download", "mkl-dynamic-ilp64-iomp"]
+default = ["download", "mkl-static-ilp64-seq"]
 
 # MKL config
 # https://software.intel.com/content/www/us/en/develop/articles/intel-math-kernel-library-intel-mkl-and-pkg-config-tool.html

--- a/intel-mkl-src/Cargo.toml
+++ b/intel-mkl-src/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 links = "mkl_core"
 
 [features]
-default = ["download", "mkl-static-ilp64-seq"]
+default = ["download", "mkl-static-ilp64-iomp"]
 
 # MKL config
 # https://software.intel.com/content/www/us/en/develop/articles/intel-math-kernel-library-intel-mkl-and-pkg-config-tool.html

--- a/intel-mkl-tool/Cargo.toml
+++ b/intel-mkl-tool/Cargo.toml
@@ -24,7 +24,7 @@ pkg-config = "0.3.17"
 # archive
 curl = { version = "0.4.29", optional = true }
 tar  = { version = "0.4.29", optional = true }
-zstd = { version = "0.6.1",  optional = true }
+zstd = { version = "0.8",  optional = true }
 
 # CLI
 structopt = { version = "0.3.15", optional = true }

--- a/intel-mkl-tool/Cargo.toml
+++ b/intel-mkl-tool/Cargo.toml
@@ -24,7 +24,7 @@ pkg-config = "0.3.17"
 # archive
 curl = { version = "0.4.29", optional = true }
 tar  = { version = "0.4.29", optional = true }
-zstd = { version = "0.8",  optional = true }
+zstd = { version = "0.8",    optional = true }
 
 # CLI
 structopt = { version = "0.3.15", optional = true }


### PR DESCRIPTION
Since the upgrade of Zstandard to 1.5.0, a lot of crates are upgrading to `zstd-rs` version 0.8 to take advantage of the speed improvements. This is clashing with the "tools" CLI application.