### PR TITLE
Add oneAPI distribution support for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Redistribution of Intel MKL as a crate. Tested on Linux, macOS, and Windows (sin
   - `static` means MKL will be linked statically, and `dynamic` means MKL will be linked dynamically
   - `lp64` means 32-bit integer interface, `ilp64` means 64-bit integer interface
   - `iomp` means MKL uses Intel OpenMP, `seq` means sequential execution, e.g. no parallelization
-    - OpenMP is not supported for Windows currently [#46](https://github.com/rust-math/intel-mkl-src/issues/46)
+    - For OpenMP supported on Windows check [#46](https://github.com/rust-math/intel-mkl-src/issues/46)
   - default is `mkl-static-ilp64-seq`, and you must choose one of them.
   - macOS is not supported [#42](https://github.com/rust-math/intel-mkl-src/issues/42)
 
@@ -59,6 +59,7 @@ This crate seeks system MKL libraries, e.g. installed by [apt], [yum], or offici
 - Seek a directory set by `${MKLROOT}` environment variable
 - Seek default installation path
   - `/opt/intel/mkl` for Linux
+  - `C:\Program Files (x86)\Intel\oneAPI\` for Windows with oneAPI distribution
   - `C:/Program Files (x86)/IntelSWTools/compilers_and_libraries/windows` for Windows
 
 If not found any MKL library and `download` feature is ON, this crate will download archive from AWS S3 `rust-intel-mkl` bucket.

--- a/intel-mkl-tool/src/config.rs
+++ b/intel-mkl-tool/src/config.rs
@@ -118,7 +118,10 @@ impl Config {
         };
         libs.push("mkl_core".into());
         if matches!(self.parallel, Threading::OpenMP) {
+            #[cfg(not(all(target_os = "windows", target_arch = "x86_64")))]
             libs.push("iomp5".into());
+            #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+            libs.push("libiomp5md".into());
         }
         libs
     }

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -115,11 +115,15 @@ impl Entry {
         }
 
         // Default setting for Windows installer
-        let windows_mkl =
-            PathBuf::from("C:/Program Files (x86)/IntelSWTools/compilers_and_libraries/windows");
+        let windows_mkl = if let Ok(oneapi) = std::env::var("ONEAPI_ROOT") {
+            oneapi.into()
+        } else {
+            PathBuf::from("C:/Program Files (x86)/IntelSWTools/compilers_and_libraries/windows")
+        };
         if windows_mkl.exists() {
             targets.seek(windows_mkl.join("mkl/lib/intel64"));
             targets.seek(windows_mkl.join("compiler/lib/intel64"));
+            targets.seek(windows_mkl.join("compiler/latest/windows/compiler/lib/intel64_win"));
         }
 
         if targets.found_any() {


### PR DESCRIPTION
oneAPI is suggested way of MKL distribution on Windows and it requires few tweaks to search paths
to work: search path should account for %ONEAPI_ROOT% env var, iomp library is named libiomp5md.lib
and can be located under

I was able to execute tests properly:
```
cargo test --features mkl-dynamic-lp64-iomp --no-default-features
```