### PR TITLE
Remove use * for external crates

### DIFF
--- a/intel-mkl-src/build.rs
+++ b/intel-mkl-src/build.rs
@@ -22,9 +22,9 @@
 
 #![cfg_attr(feature = "download", allow(unreachable_code))]
 
-use anyhow::*;
+use anyhow::{bail, Result};
 use intel_mkl_tool::*;
-use std::{env, path::*};
+use std::{env, path::PathBuf};
 
 #[cfg(feature = "mkl-static-lp64-iomp")]
 const MKL_CONFIG: &str = "mkl-static-lp64-iomp";

--- a/intel-mkl-tool/src/cli.rs
+++ b/intel-mkl-tool/src/cli.rs
@@ -1,4 +1,4 @@
-use anyhow::*;
+use anyhow::{bail, Result};
 use intel_mkl_tool::*;
 use std::{env, path::PathBuf};
 use structopt::StructOpt;

--- a/intel-mkl-tool/src/config.rs
+++ b/intel-mkl-tool/src/config.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use derive_more::*;
+use derive_more::Display;
 
 pub const VALID_CONFIGS: &[&str] = &[
     "mkl-dynamic-ilp64-iomp",

--- a/intel-mkl-tool/src/lib.rs
+++ b/intel-mkl-tool/src/lib.rs
@@ -92,8 +92,8 @@
 
 #![cfg_attr(not(feature = "archive"), allow(dead_code))]
 
-use anyhow::*;
-use std::path::*;
+use anyhow::{bail, Result};
+use std::path::{Path, PathBuf};
 
 mod config;
 mod entry;


### PR DESCRIPTION
Remove wildcard `use` statements from `intel-mkl-tool`, because it
causes problems like #68

Fix #68 