### PR TITLE
widen zstd version range

### DIFF
--- a/intel-mkl-src/build.rs
+++ b/intel-mkl-src/build.rs
@@ -22,7 +22,7 @@
 
 #![cfg_attr(feature = "download", allow(unreachable_code))]
 
-use anyhow::*;
+use anyhow::{bail, Error};
 use intel_mkl_tool::*;
 use std::{env, path::*};
 
@@ -43,7 +43,7 @@ const MKL_CONFIG: &str = "mkl-dynamic-ilp64-iomp";
 #[cfg(feature = "mkl-dynamic-ilp64-seq")]
 const MKL_CONFIG: &str = "mkl-dynamic-ilp64-seq";
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Error> {
     let cfg = Config::from_str(MKL_CONFIG).unwrap();
 
     // already exists on system

--- a/intel-mkl-tool/Cargo.toml
+++ b/intel-mkl-tool/Cargo.toml
@@ -24,7 +24,7 @@ pkg-config = "0.3.17"
 # archive
 curl = { version = "0.4.29", optional = true }
 tar  = { version = "0.4.29", optional = true }
-zstd = { version = "0.11",  optional = true }
+zstd = { version = "<=0.11, >=0.6",  optional = true }
 
 # CLI
 structopt = { version = "0.3.15", optional = true }

--- a/intel-mkl-tool/Cargo.toml
+++ b/intel-mkl-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "intel-mkl-tool"
-version = "0.2.0+mkl2020.1"
+version = "0.2.1+mkl2020.1"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2018"
 

--- a/intel-mkl-tool/Cargo.toml
+++ b/intel-mkl-tool/Cargo.toml
@@ -24,7 +24,7 @@ pkg-config = "0.3.17"
 # archive
 curl = { version = "0.4.29", optional = true }
 tar  = { version = "0.4.29", optional = true }
-zstd = { version = "0.6.1",  optional = true }
+zstd = { version = "0.11",  optional = true }
 
 # CLI
 structopt = { version = "0.3.15", optional = true }

--- a/intel-mkl-tool/src/cli.rs
+++ b/intel-mkl-tool/src/cli.rs
@@ -1,4 +1,4 @@
-use anyhow::*;
+use anyhow::{bail, Error};
 use intel_mkl_tool::*;
 use std::{env, path::PathBuf};
 use structopt::StructOpt;
@@ -32,7 +32,7 @@ enum Opt {
     },
 }
 
-fn main() -> Result<()> {
+fn main() -> Result<(), Error> {
     let opt = Opt::from_args();
 
     match opt {

--- a/intel-mkl-tool/src/config.rs
+++ b/intel-mkl-tool/src/config.rs
@@ -1,5 +1,5 @@
-use crate::*;
 use derive_more::*;
+use anyhow::{bail, Error};
 
 pub const VALID_CONFIGS: &[&str] = &[
     "mkl-dynamic-ilp64-iomp",
@@ -45,7 +45,7 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn from_str(name: &str) -> Result<Self> {
+    pub fn from_str(name: &str) -> Result<Self, Error> {
         let parts: Vec<_> = name.split("-").collect();
         if parts.len() != 4 {
             bail!("Invalid name: {}", name);
@@ -151,7 +151,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn name_to_config() -> Result<()> {
+    fn name_to_config() -> Result<(), Error> {
         let cfg = Config::from_str("mkl-static-lp64-iomp")?;
         assert_eq!(
             cfg,
@@ -165,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn name_to_config_to_name() -> Result<()> {
+    fn name_to_config_to_name() -> Result<(), Error> {
         for name in VALID_CONFIGS {
             let cfg = Config::from_str(name)?;
             assert_eq!(&cfg.name(), name);
@@ -174,7 +174,7 @@ mod tests {
     }
 
     #[test]
-    fn invalid_names() -> Result<()> {
+    fn invalid_names() -> Result<(), Error> {
         assert!(Config::from_str("").is_err());
         assert!(Config::from_str("static-lp64-iomp").is_err());
         assert!(Config::from_str("mkll-static-lp64-iomp").is_err());

--- a/intel-mkl-tool/src/download.rs
+++ b/intel-mkl-tool/src/download.rs
@@ -4,7 +4,7 @@ use std::fs;
 
 impl Config {
     /// Download archive from AWS S3, and expand into `${out_dir}/*.so`
-    pub fn download<P: AsRef<Path>>(&self, out_dir: P) -> Result<()> {
+    pub fn download<P: AsRef<Path>>(&self, out_dir: P) -> Result<(), Error> {
         let out_dir = out_dir.as_ref();
         if out_dir.exists() {
             fs::create_dir_all(&out_dir)?;
@@ -21,7 +21,7 @@ impl Config {
 ///
 /// - This function expands obtained data into memory space
 ///
-fn read_from_url(url: &str) -> Result<Vec<u8>> {
+fn read_from_url(url: &str) -> Result<Vec<u8>, Error> {
     let mut data = Vec::new();
     let mut handle = Easy::new();
     handle.fail_on_error(true)?;
@@ -47,7 +47,7 @@ mod tests {
         ($name:expr) => {
             paste::item! {
                 #[test]
-                fn [<download_$name>]() -> Result<()> {
+                fn [<download_$name>]() -> Result<(), Error> {
                     let name = $name;
                     let cfg = Config::from_str(name)?;
                     cfg.download(format!("test_download/{}", name))?;

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -5,6 +5,7 @@ use std::{
     fs,
     io::{self, BufRead},
 };
+use anyhow::{Error, bail};
 
 #[derive(Debug, Deref)]
 struct Targets(HashMap<String, Option<PathBuf>>);
@@ -68,7 +69,7 @@ impl Entry {
     ///
     /// Returns error if no library found
     ///
-    pub fn from_config(config: Config) -> Result<Self> {
+    pub fn from_config(config: Config) -> Result<Self, Error> {
         let mut targets = Targets::new(config);
 
         // OUT_DIR
@@ -149,7 +150,7 @@ impl Entry {
     ///
     /// - This will not work for OUT_DIR or XDG_DATA_HOME entry,
     ///   and returns Error in these cases
-    pub fn version(&self) -> Result<(u32, u32)> {
+    pub fn version(&self) -> Result<(u32, u32), Error> {
         for (path, _) in &self.found_files() {
             // assumes following directory structure:
             //

--- a/intel-mkl-tool/src/lib.rs
+++ b/intel-mkl-tool/src/lib.rs
@@ -92,7 +92,7 @@
 
 #![cfg_attr(not(feature = "archive"), allow(dead_code))]
 
-use anyhow::*;
+use anyhow::Error;
 use std::path::*;
 
 mod config;

--- a/intel-mkl-tool/src/package.rs
+++ b/intel-mkl-tool/src/package.rs
@@ -1,8 +1,9 @@
 use crate::*;
 use std::{fs, io};
+use anyhow::{Error, bail};
 
 impl Entry {
-    pub fn package(&self, out_dir: &Path) -> Result<PathBuf> {
+    pub fn package(&self, out_dir: &Path) -> Result<PathBuf, Error> {
         fs::create_dir_all(out_dir)?;
         let out = out_dir.join(format!("{}.tar.zst", self.name()));
         if out.exists() {


### PR DESCRIPTION
allows use of current zstd elsewhere in dependency tree. I checked that all the intermediate versions work correctly.