### PR TITLE
Drop "download" from default feature of intel-mkl-src crate

### DIFF
--- a/intel-mkl-src/Cargo.toml
+++ b/intel-mkl-src/Cargo.toml
@@ -16,7 +16,7 @@ build = "build.rs"
 links = "mkl_core"
 
 [features]
-default = ["download", "mkl-static-ilp64-seq"]
+default = ["mkl-static-ilp64-seq"]
 
 # MKL config
 # https://software.intel.com/content/www/us/en/develop/articles/intel-math-kernel-library-intel-mkl-and-pkg-config-tool.html


### PR DESCRIPTION
Resolve #67 