### PR TITLE
Remove xdg-data-home experimental feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ This crate seeks system MKL libraries, e.g. installed by [apt], [yum], or offici
     ```
     pkg-config --libs mkl-dynamic-lp64-iomp
     ```
-- (experimental) Seek `${XDG_DATA_HOME}/intel-mkl-tool`
 - Seek a directory set by `${MKLROOT}` environment variable
 - Seek default installation path
   - `/opt/intel/mkl` for Linux

--- a/intel-mkl-src/Cargo.toml
+++ b/intel-mkl-src/Cargo.toml
@@ -31,8 +31,6 @@ mkl-dynamic-ilp64-seq  = []
 
 # Enable downloading from AWS S3 when system MKL not found
 download = ["intel-mkl-tool/archive"]
-# (Experimental) Cache download archive ad $XDG_DATA_HOME/intel-mkl-tool/
-xdg-data-home = []
 
 [build-dependencies]
 anyhow = "1.0.58"

--- a/intel-mkl-src/build.rs
+++ b/intel-mkl-src/build.rs
@@ -55,11 +55,7 @@ fn main() -> Result<()> {
     // download if not found
     #[cfg(feature = "download")]
     {
-        let path = if cfg!(feature = "xdg-data-home") {
-            xdg_home_path()
-        } else {
-            PathBuf::from(env::var("OUT_DIR").unwrap())
-        };
+        let path = PathBuf::from(env::var("OUT_DIR").unwrap());
         println!(
             r#"cargo:warning="Download Intel MKL archive into {}""#,
             path.display()

--- a/intel-mkl-tool/src/cli.rs
+++ b/intel-mkl-tool/src/cli.rs
@@ -11,16 +11,12 @@ enum Opt {
         /// Archive name, e.g. "mkl-static-lp64-iomp". Download all archives if None
         #[structopt(long = "name")]
         name: Option<String>,
-        /// Install destination. Default is `$XDG_DATA_HOME/intel-mkl-tool/${MKL_VERSION}/`
+        /// Install destination
         #[structopt(short = "o", long = "path")]
-        path: Option<PathBuf>,
+        path: PathBuf,
     },
 
     /// Seek Intel-MKL library
-    ///
-    /// 1. pkg-config
-    /// 2. `$XDG_DATA_HOME/intel-mkl-tool`
-    /// will be sought.
     Seek {},
 
     /// Package Intel MKL libraries into an archive
@@ -37,7 +33,6 @@ fn main() -> Result<()> {
 
     match opt {
         Opt::Download { name, path } => {
-            let path = path.unwrap_or(xdg_home_path());
             if let Some(name) = name {
                 let cfg = Config::from_str(&name)?;
                 cfg.download(&path.join(cfg.to_string()))?;

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -1,4 +1,4 @@
-use crate::{mkl, xdg_home_path, Config, LinkType, VALID_CONFIGS};
+use crate::{mkl, Config, LinkType, VALID_CONFIGS};
 use anyhow::{bail, Result};
 use derive_more::Deref;
 use std::{
@@ -72,8 +72,6 @@ impl Entry {
     ///   - This exists only when the previous build downloads archive here
     /// - pkg-config `${name}`
     ///   - Installed by package manager or official downloader
-    /// - `$XDG_DATA_HOME/intel-mkl-tool/${name}`
-    ///   - Downloaded by this crate
     ///
     /// Returns error if no library found
     ///
@@ -96,10 +94,6 @@ impl Entry {
                 target: EntryTarget::PkgConfig,
             });
         }
-
-        // $XDG_DATA_HOME/intel-mkl-tool
-        let path = xdg_home_path().join(config.to_string());
-        targets.seek(&path);
 
         // $MKLROOT
         let mkl_root = std::env::var("MKLROOT").map(PathBuf::from);
@@ -156,7 +150,7 @@ impl Entry {
 
     /// Get MKL version info from its C header
     ///
-    /// - This will not work for OUT_DIR, XDG_DATA_HOME, or Pkgconfig entry,
+    /// - This will not work for OUT_DIR, or Pkgconfig entry,
     ///   and returns Error in these cases
     pub fn version(&self) -> Result<(u32, u32)> {
         for (path, _) in &self.found_files() {

--- a/intel-mkl-tool/src/lib.rs
+++ b/intel-mkl-tool/src/lib.rs
@@ -92,8 +92,6 @@
 
 #![cfg_attr(not(feature = "archive"), allow(dead_code))]
 
-use std::path::PathBuf;
-
 mod config;
 mod entry;
 
@@ -145,12 +143,4 @@ fn s3_addr() -> String {
         mkl::VERSION_YEAR,
         mkl::VERSION_UPDATE
     )
-}
-
-pub fn xdg_home_path() -> PathBuf {
-    dirs::data_local_dir().unwrap().join(format!(
-        "intel-mkl-tool/{}.{}",
-        mkl::VERSION_YEAR,
-        mkl::VERSION_UPDATE
-    ))
 }


### PR DESCRIPTION
Ready for #76 

Breaking change
-----------------
- Remove `xdg-date-home` feature from intel-mkl-src