### PR TITLE
intel-mkl-tool supports windows

### DIFF
--- a/.github/workflows/intel-mkl-sys.yml
+++ b/.github/workflows/intel-mkl-sys.yml
@@ -61,10 +61,6 @@ jobs:
           - mkl-static-lp64-seq
           - mkl-static-ilp64-iomp
           - mkl-static-ilp64-seq
-          - mkl-dynamic-lp64-iomp
-          - mkl-dynamic-lp64-seq
-          - mkl-dynamic-ilp64-iomp
-          - mkl-dynamic-ilp64-seq
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/intel-mkl-sys.yml
+++ b/.github/workflows/intel-mkl-sys.yml
@@ -51,3 +51,33 @@ jobs:
             --manifest-path=intel-mkl-sys/Cargo.toml
             --no-default-features
             --features=${{ matrix.feature }}
+
+  windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        feature:
+          - mkl-static-lp64-iomp
+          - mkl-static-lp64-seq
+          - mkl-static-ilp64-iomp
+          - mkl-static-ilp64-seq
+          - mkl-dynamic-lp64-iomp
+          - mkl-dynamic-lp64-seq
+          - mkl-dynamic-ilp64-iomp
+          - mkl-dynamic-ilp64-seq
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v1
+      - name: Get MKL using NuGet
+        run: |
+          nuget install intelmkl.devel.cluster.win-x64
+          nuget install intelmkl.static.cluster.win-x64
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: >
+            --manifest-path=intel-mkl-sys/Cargo.toml
+            --no-default-features
+            --features=${{ matrix.feature }}
+        env:
+          MKLROOT: ${{ github.workspace }}

--- a/.github/workflows/intel-mkl-tool.yml
+++ b/.github/workflows/intel-mkl-tool.yml
@@ -83,3 +83,20 @@ jobs:
           --manifest-path=intel-mkl-tool/Cargo.toml
           --release
           --example seek
+
+  seek-windows:
+    runs-on: windows-2022
+    steps:
+    - uses: actions/checkout@v1
+    - name: Get MKL using NuGet
+      run: nuget install intelmkl.devel.win-x64
+    - name: Run seek example
+      uses: actions-rs/cargo@v1
+      with:
+        command: run
+        args: >
+          --manifest-path=intel-mkl-tool/Cargo.toml
+          --release
+          --example seek
+      env:
+        MKLROOT: ${{ github.workspace }}

--- a/.github/workflows/intel-mkl-tool.yml
+++ b/.github/workflows/intel-mkl-tool.yml
@@ -89,7 +89,9 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Get MKL using NuGet
-      run: nuget install intelmkl.devel.win-x64
+      run: |
+        nuget install intelmkl.devel.cluster.win-x64
+        nuget install intelmkl.static.cluster.win-x64
     - name: Run seek example
       uses: actions-rs/cargo@v1
       with:

--- a/intel-mkl-tool/src/config.rs
+++ b/intel-mkl-tool/src/config.rs
@@ -159,59 +159,6 @@ impl Config {
             .map(|name| Self::from_str(name).unwrap())
             .collect()
     }
-
-    /// Common components
-    ///
-    /// The order must be following (or equivalent libs)
-    ///
-    /// mkl_intel_lp64 > mkl_intel_thread > mkl_core > iomp5
-    ///
-    pub fn libs(&self) -> Vec<String> {
-        let mut libs = Vec::new();
-        match self.index_size {
-            DataModel::LP64 => {
-                libs.push("mkl_intel_lp64".into());
-            }
-            DataModel::ILP64 => {
-                libs.push("mkl_intel_ilp64".into());
-            }
-        };
-        match self.parallel {
-            Threading::OpenMP => {
-                libs.push("mkl_intel_thread".into());
-            }
-            Threading::Sequential => {
-                libs.push("mkl_sequential".into());
-            }
-        };
-        libs.push("mkl_core".into());
-        if matches!(self.parallel, Threading::OpenMP) {
-            libs.push("iomp5".into());
-        }
-        libs
-    }
-
-    /// Dynamically loaded libraries, e.g. `libmkl_vml_avx2.so`
-    ///
-    /// - MKL seeks additional shared library **on runtime**.
-    ///   This function lists these files for packaging.
-    pub fn additional_libs(&self) -> Vec<String> {
-        match self.link {
-            LinkType::Static => Vec::new(),
-            LinkType::Dynamic => {
-                let mut libs = Vec::new();
-                for prefix in &["mkl", "mkl_vml"] {
-                    for suffix in &["def", "avx", "avx2", "avx512", "avx512_mic", "mc", "mc3"] {
-                        libs.push(format!("{}_{}", prefix, suffix));
-                    }
-                }
-                libs.push("mkl_rt".into());
-                libs.push("mkl_vml_mc2".into());
-                libs.push("mkl_vml_cmpt".into());
-                libs
-            }
-        }
-    }
 }
 
 #[cfg(test)]

--- a/intel-mkl-tool/src/config.rs
+++ b/intel-mkl-tool/src/config.rs
@@ -1,6 +1,19 @@
 use anyhow::{bail, Result};
 use std::{fmt, str::FromStr};
 
+macro_rules! impl_otherwise {
+    ($e:ident, $a:ident, $b:ident) => {
+        impl $e {
+            pub fn otherwise(&self) -> Self {
+                match self {
+                    $e::$a => $e::$b,
+                    $e::$b => $e::$a,
+                }
+            }
+        }
+    };
+}
+
 pub const VALID_CONFIGS: &[&str] = &[
     "mkl-dynamic-ilp64-iomp",
     "mkl-dynamic-ilp64-seq",
@@ -18,6 +31,7 @@ pub enum LinkType {
     Static,
     Dynamic,
 }
+impl_otherwise!(LinkType, Static, Dynamic);
 
 impl fmt::Display for LinkType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -56,6 +70,7 @@ pub enum DataModel {
     /// `int`, `long` and pointer are 64bit, i.e. `sizeof(int) == 8`
     ILP64,
 }
+impl_otherwise!(DataModel, LP64, ILP64);
 
 impl fmt::Display for DataModel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -91,6 +106,8 @@ pub enum Threading {
     /// No OpenMP runtime.
     Sequential,
 }
+
+impl_otherwise!(Threading, OpenMP, Sequential);
 
 impl Default for Threading {
     fn default() -> Self {

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -205,6 +205,7 @@ impl Library {
             return Ok(lib);
         }
         if let Ok(mklroot) = std::env::var("MKLROOT") {
+            log::info!("MKLROOT environment variable is detected: {}", mklroot);
             if let Some(lib) = Self::seek_directory(config, mklroot)? {
                 return Ok(lib);
             }
@@ -269,6 +270,7 @@ impl Library {
 
     /// Print `cargo:rustc-link-*` metadata to stdout
     pub fn print_cargo_metadata(&self) -> Result<()> {
+        println!("cargo:rerun-if-env-changed=MKLROOT");
         println!("cargo:rustc-link-search={}", self.library_dir.display());
         if let Some(iomp5_dir) = &self.iomp5_dir {
             if iomp5_dir != &self.library_dir {

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -198,7 +198,7 @@ impl Library {
     /// - Seek the directory specified by `$MKLROOT` environment variable
     /// - Seek well-known directory
     ///   - `/opt/intel` for Linux
-    ///   - `C:/Program Files (x86)/IntelSWTools/` for Windows
+    ///   - `C:/Program Files (x86)/IntelSWTools/` and `C:/Program Files (x86)/Intel/oneAPI/` for Windows
     ///
     pub fn new(config: Config) -> Result<Self> {
         if let Some(lib) = Self::pkg_config(config)? {
@@ -209,7 +209,11 @@ impl Library {
                 return Ok(lib);
             }
         }
-        for path in ["/opt/intel", "C:/Program Files (x86)/IntelSWTools/"] {
+        for path in [
+            "/opt/intel",
+            "C:/Program Files (x86)/IntelSWTools/",
+            "C:/Program Files (x86)/Intel/oneAPI/",
+        ] {
             let path = Path::new(path);
             if let Some(lib) = Self::seek_directory(config, path)? {
                 return Ok(lib);
@@ -249,7 +253,7 @@ impl Library {
             if !line.starts_with("#define") {
                 continue;
             }
-            let ss: Vec<&str> = line.split(' ').collect();
+            let ss: Vec<&str> = line.split_whitespace().collect();
             match ss[1] {
                 "__INTEL_MKL__" => year = Some(ss[2].parse()?),
                 "__INTEL_MKL_MINOR__" => minor = Some(ss[2].parse()?),

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -28,7 +28,12 @@ pub fn mkl_libs(cfg: Config) -> Vec<String> {
         }
     };
     libs.push("mkl_core".into());
-    libs
+
+    if cfg!(target_os = "windows") && cfg.link == LinkType::Dynamic {
+        libs.into_iter().map(|lib| format!("{}_dll", lib)).collect()
+    } else {
+        libs
+    }
 }
 
 /// MKL Libraries to be loaded dynamically
@@ -45,7 +50,12 @@ pub fn mkl_dyn_libs(cfg: Config) -> Vec<String> {
             libs.push("mkl_rt".into());
             libs.push("mkl_vml_mc2".into());
             libs.push("mkl_vml_cmpt".into());
-            libs
+
+            if cfg!(target_os = "windows") {
+                libs.into_iter().map(|lib| format!("{}_dll", lib)).collect()
+            } else {
+                libs
+            }
         }
     }
 }
@@ -53,14 +63,13 @@ pub fn mkl_dyn_libs(cfg: Config) -> Vec<String> {
 /// Filename convention for MKL libraries.
 pub fn mkl_file_name(link: LinkType, name: &str) -> String {
     if cfg!(target_os = "windows") {
-        match link {
-            LinkType::Static => {
-                format!("{}.lib", name)
-            }
-            LinkType::Dynamic => {
-                format!("{}_dll.lib", name)
-            }
-        }
+        // On windows
+        //
+        // - Static:  mkl_core.lib
+        // - Dynamic: mkl_core_dll.lib
+        //
+        // and `_dll` suffix is added in [mkl_libs] and [mkl_dyn_libs]
+        format!("{}.lib", name)
     } else {
         match link {
             LinkType::Static => {

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -74,7 +74,7 @@ pub fn mkl_file_name(link: LinkType, name: &str) -> String {
 }
 
 pub const OPENMP_RUNTIME_LIB: &str = if cfg!(target_os = "windows") {
-    "iomp5md"
+    "libiomp5md"
 } else {
     "iomp5"
 };
@@ -85,10 +85,10 @@ pub fn openmp_runtime_file_name(link: LinkType) -> String {
     if cfg!(target_os = "windows") {
         match link {
             LinkType::Static => {
-                format!("lib{}.lib", name)
+                format!("{}.lib", name)
             }
             LinkType::Dynamic => {
-                format!("lib{}.dll", name)
+                format!("{}.dll", name)
             }
         }
     } else {

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -209,11 +209,11 @@ impl Library {
                 if path.is_dir() {
                     return None;
                 }
-                // Skip files under directory for ia32
+                // Skip files for 32bit system under `ia32*/` and `win-x86`
                 if path.components().any(|c| {
                     if let std::path::Component::Normal(c) = c {
                         if let Some(c) = c.to_str() {
-                            if c.starts_with("ia32") {
+                            if c.starts_with("ia32") || c == "win-x86" {
                                 return true;
                             }
                         }

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -364,7 +364,9 @@ impl Library {
             }
         }
         let mut libs = mkl_libs(self.config);
-        libs.push(OPENMP_RUNTIME_LIB.to_string());
+        if self.config.parallel == Threading::OpenMP {
+            libs.push(OPENMP_RUNTIME_LIB.to_string());
+        }
         for lib in libs {
             match self.config.link {
                 LinkType::Static => {

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -412,27 +412,11 @@ impl Library {
         }
 
         if self.config.parallel == Threading::OpenMP {
-            match (
-                self.iomp5_static_dir.as_ref(),
-                self.iomp5_dynamic_dir.as_ref(),
-            ) {
-                (Some(static_dir), Some(dynamic_dir)) => match self.config.link {
-                    LinkType::Static => {
-                        println!("cargo:rustc-link-search={}", static_dir.display());
-                    }
-                    LinkType::Dynamic => {
-                        println!("cargo:rustc-link-search={}", dynamic_dir.display());
-                    }
-                },
-                (Some(static_dir), None) => {
-                    println!("cargo:rustc-link-search={}", static_dir.display());
-                }
-                (None, Some(dynamic_dir)) => {
-                    println!("cargo:rustc-link-search={}", dynamic_dir.display());
-                }
-                _ => {
-                    bail!("OpenMP runtime not found");
-                }
+            if let Some(ref dir) = self.iomp5_static_dir {
+                println!("cargo:rustc-link-search={}", dir.display());
+            }
+            if let Some(ref dir) = self.iomp5_dynamic_dir {
+                println!("cargo:rustc-link-search={}", dir.display());
             }
             println!("cargo:rustc-link-lib={}", OPENMP_RUNTIME_LIB);
         }

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -85,10 +85,10 @@ pub fn openmp_runtime_file_name(link: LinkType) -> String {
     if cfg!(target_os = "windows") {
         match link {
             LinkType::Static => {
-                format!("{}.lib", name)
+                format!("lib{}.lib", name)
             }
             LinkType::Dynamic => {
-                format!("{}.dll", name)
+                format!("lib{}.dll", name)
             }
         }
     } else {


### PR DESCRIPTION
- Add seek test for Windows using [NuGet installer of MKL](https://www.intel.com/content/www/us/en/develop/documentation/installation-guide-for-intel-oneapi-toolkits-windows/top/installation/install-using-package-managers/nuget.html)
  - Default windows installer does not works on GitHub Actions
- Rewrite seek algorithm to support naming rule on Windows