### PR TITLE
Skip unreadable directory

### DIFF
--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -94,8 +94,7 @@ impl Library {
         let mut library_dir = None;
         let mut include_dir = None;
         let mut iomp5_dir = None;
-        for entry in walkdir::WalkDir::new(root_dir) {
-            let entry = entry.unwrap();
+        for entry in walkdir::WalkDir::new(root_dir).into_iter().flatten() {
             if entry.path_is_symlink() {
                 continue;
             }


### PR DESCRIPTION
This PR makes intel-mkl-tool work with [intel-oneapi-mkl in ArchLinux](https://www.archlinux.jp/packages/community/x86_64/intel-oneapi-mkl/), which install MKL into `/usr`.