### PR TITLE
Executable for seeking MKL in system as an example

### DIFF
--- a/.github/workflows/intel-mkl-tool.yml
+++ b/.github/workflows/intel-mkl-tool.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v1
     - uses: actions-rs/toolchain@v1
       with:
-        toolchain: "1.56.0"
+        toolchain: 1.61.0
         profile: minimal
         default: true
         override: true

--- a/.github/workflows/intel-mkl-tool.yml
+++ b/.github/workflows/intel-mkl-tool.yml
@@ -7,7 +7,7 @@ on:
   pull_request: {}
 
 jobs:
-  test:
+  cargo-test:
     strategy:
       fail-fast: false
       matrix:
@@ -29,27 +29,18 @@ jobs:
       with:
         command: test
         args: --manifest-path=intel-mkl-tool/Cargo.toml
-    - name: cargo test with no-default-features
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: >
-          --manifest-path=intel-mkl-tool/Cargo.toml
-          --no-default-features
 
-  test_pkg_config:
+  seek:
     runs-on: ubuntu-22.04
     container:
       image: ghcr.io/rust-math/rust-mkl:1.62.1-2020.1
     steps:
     - uses: actions/checkout@v1
-    - uses: actions-rs/cargo@v1
-      name: Seek /opt/intel
+    - name: Run seek example
+      uses: actions-rs/cargo@v1
       with:
-        command: test
+        command: run
         args: >
           --manifest-path=intel-mkl-tool/Cargo.toml
-          pkg_config
-          --
-          --ignored
-          --show-output
+          --release
+          --example seek

--- a/intel-mkl-src/Cargo.toml
+++ b/intel-mkl-src/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.7.0+mkl2020.1"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2018"
 
-rust-version = "1.56.0" # MSRV is introduced
+rust-version = "1.61.0"
 
 description = "Redistribution of Intel(R) MKL as a crate"
 repository = "https://github.com/rust-math/intel-mkl-src"

--- a/intel-mkl-sys/Cargo.toml
+++ b/intel-mkl-sys/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0+mkl2020.1"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2018"
 
-rust-version = "1.56.0" # MSRV is introduced
+rust-version = "1.61.0"
 
 description = "FFI for Intel(R) MKL"
 repository  = "https://github.com/rust-math/intel-mkl-src"

--- a/intel-mkl-tool/Cargo.toml
+++ b/intel-mkl-tool/Cargo.toml
@@ -3,7 +3,7 @@ name = "intel-mkl-tool"
 version = "0.4.0"
 authors = ["Toshiki Teramura <toshiki.teramura@gmail.com>"]
 edition = "2018"
-rust-version = "1.56.0" # MSRV is introduced
+rust-version = "1.61.0"
 
 description = "CLI utility for redistributiing Intel(R) MKL"
 repository  = "https://github.com/rust-math/intel-mkl-src"

--- a/intel-mkl-tool/examples/seek.rs
+++ b/intel-mkl-tool/examples/seek.rs
@@ -1,0 +1,18 @@
+use intel_mkl_tool::*;
+
+fn main() {
+    for cfg in Config::possibles() {
+        let lib = Library::new(cfg);
+        print!(
+            "{:>7} {:>5} {:>4}",
+            cfg.link.to_string(),
+            cfg.index_size.to_string(),
+            cfg.parallel.to_string()
+        );
+        if let Ok(lib) = lib {
+            println!(" {}", lib.library_dir.display());
+        } else {
+            println!(" Not found");
+        }
+    }
+}

--- a/intel-mkl-tool/examples/seek.rs
+++ b/intel-mkl-tool/examples/seek.rs
@@ -1,6 +1,8 @@
 use intel_mkl_tool::*;
+use std::process::ExitCode;
 
-fn main() {
+fn main() -> ExitCode {
+    let mut num_not_found = 0;
     for cfg in Config::possibles() {
         let lib = Library::new(cfg);
         print!(
@@ -12,7 +14,9 @@ fn main() {
         if let Ok(lib) = lib {
             println!(" {}", lib.library_dir.display());
         } else {
+            num_not_found += 1;
             println!(" Not found");
         }
     }
+    return ExitCode::from(num_not_found);
 }

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -282,31 +282,3 @@ impl Library {
         Ok(())
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Seek /opt/intel in Linux system
-    #[ignore]
-    #[test]
-    fn seek_opt_intel() {
-        for cfg in Config::possibles() {
-            let lib = Library::seek_directory(cfg, "/opt/intel").unwrap().unwrap();
-            dbg!(lib.version().unwrap());
-        }
-    }
-
-    #[ignore]
-    #[test]
-    fn pkg_config() {
-        for cfg in Config::possibles() {
-            // pkg-config will not work for `mkl-*-*-iomp` cases
-            if cfg.parallel == Threading::OpenMP {
-                continue;
-            }
-            let lib = Library::pkg_config(cfg).unwrap().unwrap();
-            dbg!(lib.version().unwrap());
-        }
-    }
-}


### PR DESCRIPTION
This bumps up MSRV to 1.61.0 to use `std::process:ExitCode`