### PR TITLE
Test case for seeking MKL installed by apt

### DIFF
--- a/.github/workflows/intel-mkl-tool.yml
+++ b/.github/workflows/intel-mkl-tool.yml
@@ -52,6 +52,7 @@ jobs:
       matrix:
         image:
           - ubuntu:22.04
+          - ubuntu:20.04
           - debian:10
     container:
       image: ${{ matrix.image }}

--- a/.github/workflows/intel-mkl-tool.yml
+++ b/.github/workflows/intel-mkl-tool.yml
@@ -45,12 +45,22 @@ jobs:
           --release
           --example seek
 
-  seek-ubuntu:
+  seek-apt:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - ubuntu:22.04
+          - debian:10
     container:
-      image: ubuntu:22.04
+      image: ${{ matrix.image }}
     steps:
     - uses: actions/checkout@v1
+
+    - name: Add non-free registry
+      if: ${{ startsWith(matrix.image, 'debian') }}
+      run: sed -i "s/main$/main contrib non-free/" /etc/apt/sources.list
 
     - name: Install MKL using apt
       run: |

--- a/.github/workflows/intel-mkl-tool.yml
+++ b/.github/workflows/intel-mkl-tool.yml
@@ -44,3 +44,31 @@ jobs:
           --manifest-path=intel-mkl-tool/Cargo.toml
           --release
           --example seek
+
+  seek-ubuntu:
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:22.04
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Install MKL using apt
+      run: |
+        export DEBIAN_FRONTEND=noninteractive
+        apt update
+        apt install -y intel-mkl curl gcc
+
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: 1.61.0
+        profile: minimal
+        default: true
+        override: true
+    - name: Run seek example
+      uses: actions-rs/cargo@v1
+      with:
+        command: run
+        args: >
+          --manifest-path=intel-mkl-tool/Cargo.toml
+          --release
+          --example seek

--- a/intel-mkl-tool/Cargo.toml
+++ b/intel-mkl-tool/Cargo.toml
@@ -10,6 +10,10 @@ repository  = "https://github.com/rust-math/intel-mkl-src"
 keywords    = []
 license     = "MIT"
 
+[features]
+# Do not allow linking dynamic library for mkl-static-*-iomp
+openmp-strict-link-type = []
+
 [dependencies]
 anyhow = "1.0.58"
 log = "0.4.17"

--- a/intel-mkl-tool/Cargo.toml
+++ b/intel-mkl-tool/Cargo.toml
@@ -12,4 +12,8 @@ license     = "MIT"
 
 [dependencies]
 anyhow = "1.0.58"
+log = "0.4.17"
 walkdir = "2.3.2"
+
+[dev-dependencies]
+env_logger = "0.9.0"

--- a/intel-mkl-tool/examples/seek.rs
+++ b/intel-mkl-tool/examples/seek.rs
@@ -2,20 +2,16 @@ use intel_mkl_tool::*;
 use std::process::ExitCode;
 
 fn main() -> ExitCode {
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Info)
+        .init();
     let mut num_not_found = 0;
     for cfg in Config::possibles() {
-        let lib = Library::new(cfg);
-        print!(
-            "{:>7} {:>5} {:>4}",
-            cfg.link.to_string(),
-            cfg.index_size.to_string(),
-            cfg.parallel.to_string()
-        );
-        if let Ok(lib) = lib {
-            println!(" {}", lib.library_dir.display());
+        log::info!("Seek {}", cfg);
+        if let Ok(lib) = Library::new(cfg) {
+            log::info!("{:?}", lib);
         } else {
             num_not_found += 1;
-            println!(" Not found");
         }
     }
     return ExitCode::from(num_not_found);

--- a/intel-mkl-tool/src/entry.rs
+++ b/intel-mkl-tool/src/entry.rs
@@ -149,38 +149,22 @@ impl Library {
                 (LinkType::Static, STATIC_EXTENSION) => match name {
                     "mkl_core" => {
                         log::info!("Found: {}", path.display());
-                        ensure!(
-                            library_dir.replace(dir).is_none(),
-                            "Two or more MKL found in {}",
-                            root_dir.display()
-                        );
+                        library_dir = Some(dir);
                     }
                     "iomp5" => {
                         log::info!("Found: {}", path.display());
-                        ensure!(
-                            iomp5_dir.replace(dir).is_none(),
-                            "Two or more MKL found in {}",
-                            root_dir.display()
-                        );
+                        iomp5_dir = Some(dir);
                     }
                     _ => {}
                 },
                 (LinkType::Dynamic, std::env::consts::DLL_EXTENSION) => match name {
                     "mkl_core" => {
                         log::info!("Found: {}", path.display());
-                        ensure!(
-                            library_dir.replace(dir).is_none(),
-                            "Two or more MKL found in {}",
-                            root_dir.display()
-                        )
+                        library_dir = Some(dir);
                     }
                     "iomp5" => {
                         log::info!("Found: {}", path.display());
-                        ensure!(
-                            iomp5_dir.replace(dir).is_none(),
-                            "Two or more MKL found in {}",
-                            root_dir.display()
-                        );
+                        iomp5_dir = Some(dir);
                     }
                     _ => {}
                 },


### PR DESCRIPTION
Split from #92 

Changes
---------
- Do not skip symlink
- Take last appeared library if many library files are found
- Allow link dynamic library of OpenMP runtime (`libiomp5.so`) even if `mkl-static-*-iomp` case. This is due to some distribution including Ubuntu does not provide `libiomp5.a`.
- Add `openmp-strict-link-type` feature to disable above.