### PR TITLE
ocipkg 0.2.6, anonymous pulling container

### DIFF
--- a/.github/workflows/intel-mkl-sys.yml
+++ b/.github/workflows/intel-mkl-sys.yml
@@ -34,17 +34,11 @@ jobs:
       image: ${{ matrix.image }}
     steps:
       - uses: actions/checkout@v1
-
       - uses: actions-rs/cargo@v1
         if: matrix.image == 'rust:1.62.1'
         with:
           command: install
-          args: ocipkg-cli --version=0.2.3
-      - name: Login to ghcr.io
-        if: matrix.image == 'rust:1.62.1'
-        run: |
-          ocipkg login -u ${{ github.repository_owner }} -p ${{ github.token }} https://ghcr.io
-
+          args: ocipkg-cli
       - uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/intel-mkl-sys.yml
+++ b/.github/workflows/intel-mkl-sys.yml
@@ -7,35 +7,47 @@ on:
   pull_request: {}
 
 jobs:
-  linux:
+  linux-official:
     strategy:
       fail-fast: false
       matrix:
-        image:
-          - ghcr.io/rust-math/rust-mkl:1.62.1-2020.1
-          - rust:1.62.1
         feature:
-          - ""
+          - ""  # test of no-feature
           - mkl-static-lp64-iomp
           - mkl-static-lp64-seq
           - mkl-static-ilp64-iomp
           - mkl-static-ilp64-seq
-        include:
-          - image: ghcr.io/rust-math/rust-mkl:1.62.1-2020.1
-            feature: mkl-dynamic-lp64-iomp
-          - image: ghcr.io/rust-math/rust-mkl:1.62.1-2020.1
-            feature: mkl-dynamic-lp64-seq
-          - image: ghcr.io/rust-math/rust-mkl:1.62.1-2020.1
-            feature: mkl-dynamic-ilp64-iomp
-          - image: ghcr.io/rust-math/rust-mkl:1.62.1-2020.1
-            feature: mkl-dynamic-ilp64-seq
+          - mkl-dynamic-lp64-iomp
+          - mkl-dynamic-lp64-seq
+          - mkl-dynamic-ilp64-iomp
+          - mkl-dynamic-ilp64-seq
     runs-on: ubuntu-22.04
     container:
-      image: ${{ matrix.image }}
+      image: ghcr.io/rust-math/rust-mkl:1.62.1-2020.1
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/cargo@v1
-        if: matrix.image == 'rust:1.62.1'
+        with:
+          command: test
+          args: >
+            --manifest-path=intel-mkl-sys/Cargo.toml
+            --features=${{ matrix.feature }}
+
+  linux-ocipkg:
+    strategy:
+      fail-fast: false
+      matrix:
+        feature:
+          - mkl-static-lp64-iomp
+          - mkl-static-lp64-seq
+          - mkl-static-ilp64-iomp
+          - mkl-static-ilp64-seq
+    runs-on: ubuntu-22.04
+    container:
+      image: rust:1.62.1
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/cargo@v1
         with:
           command: install
           args: ocipkg-cli
@@ -46,7 +58,7 @@ jobs:
             --manifest-path=intel-mkl-sys/Cargo.toml
             --features=${{ matrix.feature }}
 
-  windows:
+  windows-nuget:
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ In addition to original Keep-a-Changelog, we use following rules:
 
 ### Added
 - Try ocipkg when MKL not found https://github.com/rust-math/intel-mkl-src/pull/88
+  - ocipkg 0.2.6, anonymous pulling container https://github.com/rust-math/intel-mkl-src/pull/101
 
 ### Removed
 - Split container management as another repository https://github.com/rust-math/rust-mkl-container

--- a/intel-mkl-src/Cargo.toml
+++ b/intel-mkl-src/Cargo.toml
@@ -31,5 +31,5 @@ mkl-dynamic-ilp64-seq  = []
 
 [build-dependencies]
 anyhow = "1.0.58"
-ocipkg = "0.2.3"
+ocipkg = "0.2.6"
 intel-mkl-tool = { version = "0.8.0-rc.0", path = "../intel-mkl-tool", default-features = false }


### PR DESCRIPTION
ocipkg 0.2.6 can download public container without login https://github.com/termoshtt/ocipkg/pull/74