### PR TITLE
Fail if ocipkg::link_package fails

### DIFF
--- a/intel-mkl-src/build.rs
+++ b/intel-mkl-src/build.rs
@@ -67,16 +67,16 @@ fn main() -> Result<()> {
     // unless user set `LD_LIBRARY_PATH` explictly.
     if cfg.link == LinkType::Static {
         if cfg!(target_os = "linux") {
-            let _ = ocipkg::link_package(&format!(
+            ocipkg::link_package(&format!(
                 "ghcr.io/rust-math/rust-mkl/linux/{}:2020.1-3038006115",
                 MKL_CONFIG
-            ));
+            ))?;
         }
         if cfg!(target_os = "windows") {
-            let _ = ocipkg::link_package(&format!(
+            ocipkg::link_package(&format!(
                 "ghcr.io/rust-math/rust-mkl/windows/{}:2022.0-3038006115",
                 MKL_CONFIG
-            ));
+            ))?;
         }
     }
 


### PR DESCRIPTION
Fail if `ocipkg::link_package` fails. Errors are ignored currently.

`ocipkg::link_package` was returning `Error: Authorization failed: https://ghcr.io/token`. I fixed it by deleting the file `~/.docker/config.json`. Running `docker login ghcr.io` would likely also fix it.

- https://github.com/termoshtt/ocipkg/issues/115