### PR TITLE
build: download and unpack container in OUT_DIR

### DIFF
--- a/intel-mkl-src/Cargo.toml
+++ b/intel-mkl-src/Cargo.toml
@@ -32,6 +32,9 @@ mkl-dynamic-ilp64-seq  = []
 [build-dependencies]
 anyhow = "1.0.58"
 ocipkg = "0.2.8"
+flate2 = "1.0.28"
+log = "0.4.21"
+tar = "0.4.40"
 
 [build-dependencies.intel-mkl-tool]
 path = "../intel-mkl-tool"

--- a/intel-mkl-src/build.rs
+++ b/intel-mkl-src/build.rs
@@ -22,7 +22,8 @@
 
 use anyhow::Result;
 use intel_mkl_tool::*;
-use std::str::FromStr;
+use ocipkg::{distribution, local, ImageName};
+use std::{env, fs, path::PathBuf, str::FromStr};
 
 macro_rules! def_mkl_config {
     ($cfg:literal) => {
@@ -67,18 +68,68 @@ fn main() -> Result<()> {
     // unless user set `LD_LIBRARY_PATH` explictly.
     if cfg.link == LinkType::Static {
         if cfg!(target_os = "linux") {
-            let _ = ocipkg::link_package(&format!(
+            link_package(&format!(
                 "ghcr.io/rust-math/rust-mkl/linux/{}:2020.1-3038006115",
                 MKL_CONFIG
-            ));
+            ))?;
         }
         if cfg!(target_os = "windows") {
-            let _ = ocipkg::link_package(&format!(
+            link_package(&format!(
                 "ghcr.io/rust-math/rust-mkl/windows/{}:2022.0-3038006115",
                 MKL_CONFIG
-            ));
+            ))?;
         }
     }
 
+    Ok(())
+}
+
+/// Copied from ocipkg to effectively backport the addition made in this commit upstream:
+/// https://github.com/termoshtt/ocipkg/commit/7b382892834e577ccf65dd7b368f796903722f63
+fn link_package(image_name: &str) -> Result<()> {
+    const STATIC_PREFIX: &str = if cfg!(target_os = "windows") {
+        ""
+    } else {
+        "lib"
+    };
+
+    let image_name = ImageName::parse(image_name)?;
+
+    let mut dir = PathBuf::from(env::var("OUT_DIR").unwrap());
+    dir.push("ocipkg");
+    if let Some(port) = image_name.port {
+        dir.push(format!("{}__{}", image_name.hostname, port));
+    } else {
+        dir.push(&image_name.hostname);
+    }
+    dir.push(image_name.name.as_str());
+    dir.push(format!("__{}", image_name.reference));
+
+    if !dir.exists() {
+        distribution::get_image(&image_name)?;
+    }
+    println!("cargo:rustc-link-search={}", dir.display());
+    for path in fs::read_dir(&dir)?.filter_map(|entry| {
+        let path = entry.ok()?.path();
+        path.is_file().then(|| path)
+    }) {
+        let name = path
+            .file_stem()
+            .unwrap()
+            .to_str()
+            .expect("Non UTF-8 is not supported");
+        let name = if let Some(name) = name.strip_prefix(STATIC_PREFIX) {
+            name
+        } else {
+            continue;
+        };
+        if let Some(ext) = path.extension() {
+            if ext == STATIC_EXTENSION {
+                println!("cargo:rustc-link-lib=static={}", name);
+            }
+        }
+    }
+    println!("cargo:rerun-if-changed={}", dir.display());
+    println!("cargo:rerun-if-env-changed=XDG_DATA_HOME");
     Ok(())
 }


### PR DESCRIPTION
Ensures the MKL libraries are inside `target`.